### PR TITLE
Render header and footer on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,8 @@
 import { getCollection } from "astro:content";
 import Layout from "@/layouts/Layout.astro";
 import Card from "@/components/Card.astro";
+import Header from "@/components/Header.astro";
+import Footer from "@/components/Footer.astro";
 import { SITE } from "@/config";
 
 const posts = (await getCollection("blog", ({ data }) => !data.draft))
@@ -9,6 +11,7 @@ const posts = (await getCollection("blog", ({ data }) => !data.draft))
 ---
 
 <Layout>
+  <Header />
   <main id="main-content" class="mx-auto max-w-app px-4 py-16">
     <h1 class="mb-2 text-center text-4xl font-bold">{SITE.title}</h1>
     <p class="mb-8 text-center">{SITE.desc}</p>
@@ -18,4 +21,5 @@ const posts = (await getCollection("blog", ({ data }) => !data.draft))
       </ul>
     )}
   </main>
+  <Footer />
 </Layout>


### PR DESCRIPTION
## Summary
- show site navigation and socials on the index page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685d3f66c3c883239835b3560fb58882