### PR TITLE
fix: make OG font fallback configurable and less noisy

### DIFF
--- a/src/utils/loadGoogleFont.ts
+++ b/src/utils/loadGoogleFont.ts
@@ -1,3 +1,20 @@
+import { access, readFile } from "node:fs/promises";
+
+type OgFontStyle = "normal" | "bold";
+type OgFont = {
+  name: string;
+  data: ArrayBuffer;
+  weight: number;
+  style: OgFontStyle;
+};
+
+type LocalFontConfig = {
+  name: string;
+  weight: number;
+  style: OgFontStyle;
+  paths: string[];
+};
+
 async function loadGoogleFont(
   font: string,
   text: string,
@@ -29,34 +46,115 @@ async function loadGoogleFont(
   return res.arrayBuffer();
 }
 
-async function loadGoogleFonts(
-  text: string
-): Promise<
-  Array<{ name: string; data: ArrayBuffer; weight: number; style: string }>
-> {
+async function resolveReadablePath(paths: string[]): Promise<string | null> {
+  for (const path of paths) {
+    try {
+      await access(path);
+      return path;
+    } catch {
+      // Try next path.
+    }
+  }
+
+  return null;
+}
+
+async function loadLocalFallbackFonts(): Promise<OgFont[]> {
+  const configuredRegularPath = process.env.OG_FONT_REGULAR_PATH;
+  const configuredBoldPath = process.env.OG_FONT_BOLD_PATH;
+
+  const fallbackFonts: LocalFontConfig[] = [
+    {
+      name: "DejaVu Sans",
+      weight: 400,
+      style: "normal",
+      paths: [
+        ...(configuredRegularPath ? [configuredRegularPath] : []),
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/local/share/fonts/DejaVuSans.ttf",
+      ],
+    },
+    {
+      name: "DejaVu Sans",
+      weight: 700,
+      style: "bold",
+      paths: [
+        ...(configuredBoldPath ? [configuredBoldPath] : []),
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+        "/usr/local/share/fonts/DejaVuSans-Bold.ttf",
+      ],
+    },
+  ];
+
+  const fonts = (
+    await Promise.all(
+      fallbackFonts.map(async ({ name, paths, weight, style }) => {
+        const resolvedPath = await resolveReadablePath(paths);
+
+        if (!resolvedPath) {
+          return null;
+        }
+
+        const data = await readFile(resolvedPath);
+        const copiedData = Uint8Array.from(data);
+
+        return {
+          name,
+          data: copiedData.buffer,
+          weight,
+          style,
+        } satisfies OgFont;
+      })
+    )
+  ).filter((font): font is OgFont => font !== null);
+
+  if (fonts.length > 0) {
+    return fonts;
+  }
+
+  throw new Error(
+    "No fallback fonts available for OG image generation. Set OG_FONT_REGULAR_PATH and OG_FONT_BOLD_PATH to local .ttf files."
+  );
+}
+
+async function loadGoogleFonts(text: string): Promise<OgFont[]> {
   const fontsConfig = [
     {
       name: "IBM Plex Mono",
       font: "IBM+Plex+Mono",
       weight: 400,
-      style: "normal",
+      style: "normal" as const,
     },
     {
       name: "IBM Plex Mono",
       font: "IBM+Plex+Mono",
       weight: 700,
-      style: "bold",
+      style: "bold" as const,
     },
   ];
 
-  const fonts = await Promise.all(
-    fontsConfig.map(async ({ name, font, weight, style }) => {
-      const data = await loadGoogleFont(font, text, weight);
-      return { name, data, weight, style };
-    })
+  const fonts = (
+    await Promise.all(
+      fontsConfig.map(async ({ name, font, weight, style }) => {
+        try {
+          const data = await loadGoogleFont(font, text, weight);
+          return { name, data, weight, style } satisfies OgFont;
+        } catch {
+          return null;
+        }
+      })
+    )
+  ).filter((font): font is OgFont => font !== null);
+
+  if (fonts.length > 0) {
+    return fonts;
+  }
+
+  console.warn(
+    "[og-image] Google Fonts are unreachable. Using local fallback fonts for OG image generation."
   );
 
-  return fonts;
+  return loadLocalFallbackFonts();
 }
 
 export default loadGoogleFonts;


### PR DESCRIPTION
### Motivation
- Prevent OG image generation from failing in constrained/offline builds by improving local font fallback discovery and reducing noisy per-font warnings. 
- Make fallback behavior portable and configurable across environments by allowing explicit local font paths.

### Description
- Added typed `OgFont` and `OgFontStyle` definitions and a `LocalFontConfig` shape to clarify font data handling. 
- Implemented `resolveReadablePath()` which probes multiple candidate paths with `access()` and `loadLocalFallbackFonts()` that accepts environment-configured paths (`OG_FONT_REGULAR_PATH`, `OG_FONT_BOLD_PATH`) plus common local locations. 
- Preserved Google Fonts as the primary source via `loadGoogleFont()`, but changed `loadGoogleFonts()` to silently ignore per-attempt remote failures and emit a single consolidated `console.warn` only when falling back to local fonts. 
- Convert local file buffers safely to `ArrayBuffer` and return a unified `OgFont[]` to callers.

### Testing
- Ran the production build with `npm run build` which completed successfully (build finished and Pagefind indexing succeeded). 
- Observed the Astro build output indicating pages were generated (`888 page(s) built`) and Pagefind indexed the site without OG font-related errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a9e2ee04832390b4e2e18c66fa49)